### PR TITLE
Disable cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ https://github.com/antlr/grammars-v4
 
 ##### О ABC Metric
 https://en.wikipedia.org/wiki/ABC_Software_Metric
+
+
+##### Notes for ANTLR Parsers
+
+After generating the parsers, run `optimize.py`.

--- a/complexity/parsers/c/CParser.py
+++ b/complexity/parsers/c/CParser.py
@@ -562,8 +562,6 @@ class CParser(ParserWithTimeLimit):
 
     decisionsToDFA = [DFA(ds, i) for i, ds in enumerate(atn.decisionToState)]
 
-    sharedContextCache = PredictionContextCache()
-
     literalNames = ["<INVALID>", "'__extension__'", "'__builtin_va_arg'",
                     "'__builtin_offsetof'", "'__m128'", "'__m128d'", "'__m128i'",
                     "'__typeof__'", "'__inline__'", "'__stdcall'", "'__declspec'",
@@ -825,7 +823,7 @@ class CParser(ParserWithTimeLimit):
     def __init__(self, input: TokenStream, output: TextIO = sys.stdout):
         super().__init__(input, output)
         self.checkVersion("4.7")
-        self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, self.sharedContextCache)
+        self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
         self._predicates = None
 
     class PrimaryExpressionContext(ParserRuleContext):

--- a/complexity/parsers/cpp/CPP14Parser.py
+++ b/complexity/parsers/cpp/CPP14Parser.py
@@ -1617,8 +1617,6 @@ class CPP14Parser(ParserWithTimeLimit):
 
     decisionsToDFA = [DFA(ds, i) for i, ds in enumerate(atn.decisionToState)]
 
-    sharedContextCache = PredictionContextCache()
-
     literalNames = ["<INVALID>", "<INVALID>", "<INVALID>", "'alignas'",
                     "'alignof'", "'asm'", "'auto'", "'break'", "'case'",
                     "'catch'", "'class'", "<INVALID>", "<INVALID>", "'continue'",
@@ -1862,7 +1860,7 @@ class CPP14Parser(ParserWithTimeLimit):
     def __init__(self, input: TokenStream, output: TextIO = sys.stdout):
         super().__init__(input, output)
         self.checkVersion("4.7")
-        self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, self.sharedContextCache)
+        self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
         self._predicates = None
 
     class TranslationunitContext(ParserRuleContext):

--- a/complexity/parsers/java9/Java9Parser.py
+++ b/complexity/parsers/java9/Java9Parser.py
@@ -1256,8 +1256,6 @@ class Java9Parser(ParserWithTimeLimit):
 
     decisionsToDFA = [DFA(ds, i) for i, ds in enumerate(atn.decisionToState)]
 
-    sharedContextCache = PredictionContextCache()
-
     literalNames = ["<INVALID>", "'open'", "'module'", "'requires'", "'transitive'",
                     "'uses'", "'exports'", "'opens'", "'to'", "'provides'",
                     "'with'", "<INVALID>", "<INVALID>", "'abstract'", "'assert'",
@@ -1566,7 +1564,7 @@ class Java9Parser(ParserWithTimeLimit):
     def __init__(self, input: TokenStream, output: TextIO = sys.stdout):
         super().__init__(input, output)
         self.checkVersion("4.7")
-        self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, self.sharedContextCache)
+        self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
         self._predicates = None
 
     class ReferenceTypeContext(ParserRuleContext):

--- a/complexity/parsers/python3/Python3Parser.py
+++ b/complexity/parsers/python3/Python3Parser.py
@@ -628,8 +628,6 @@ class Python3Parser(ParserWithTimeLimit):
 
     decisionsToDFA = [DFA(ds, i) for i, ds in enumerate(atn.decisionToState)]
 
-    sharedContextCache = PredictionContextCache()
-
     literalNames = ["<INVALID>", "'def'", "'return'", "'raise'", "'from'",
                     "'import'", "'as'", "'global'", "'nonlocal'", "'assert'",
                     "'if'", "'elif'", "'else'", "'while'", "'for'", "'in'",
@@ -813,7 +811,7 @@ class Python3Parser(ParserWithTimeLimit):
     def __init__(self, input: TokenStream, output: TextIO = sys.stdout):
         super().__init__(input, output)
         self.checkVersion("4.7")
-        self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, self.sharedContextCache)
+        self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
         self._predicates = None
 
     class File_inputContext(ParserRuleContext):

--- a/scripts/optimize.py
+++ b/scripts/optimize.py
@@ -125,6 +125,11 @@ def optimize(parsers_path):
             # Common optimize
             data = re.sub(r'(if .*) in \[(\w*\.\w*)\]', r'\g<1> == \g<2>', data)
 
+            # Disable use cache
+            data = re.sub(r'sharedContextCache = PredictionContextCache\(\)\n', '', data)
+            data = re.sub(r'self\.sharedContextCache',
+                          'PredictionContextCache()', data)
+
         with open(file_name, 'w') as file:
             file.write(data)
 


### PR DESCRIPTION
Теперь кэш для парсера создается заново с каждым экземпляром класса. Иначе онникогда не очищается пока жив текущий процесс и никак не ограничен по размеру.